### PR TITLE
Create Table of Contents

### DIFF
--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -7,6 +7,7 @@ import { useSiteMetadata } from '../../hooks';
 import { withPrefix } from 'gatsby';
 import Copyright from '../Sidebar/Copyright';
 import Contacts from '../Sidebar/Contacts';
+import TableOfContents from './TableOfContents';
 
 export const CopyrightFooter = () => (
   <div className={styles['post__copyright']}>
@@ -34,6 +35,7 @@ const Post = ({ post }) => {
           com
         </div>
       </Link>
+      <TableOfContents html={html} />
       <div className={styles['post__content']}>
         <Content body={html} title={title} date={date} minutes={minutes} />
       </div>

--- a/src/components/Post/TableOfContents/TableOfContents.js
+++ b/src/components/Post/TableOfContents/TableOfContents.js
@@ -17,7 +17,7 @@ const TableOfContents = ({ html }) => {
       .filter((child) => TITLE_TYPES.has(child.nodeName));
 
     titles.forEach((title) => {
-      ref.current.appendChild(title);
+      ref.current.appendChild(title); // why does this break the scroll
     });
   }, []);
 

--- a/src/components/Post/TableOfContents/TableOfContents.js
+++ b/src/components/Post/TableOfContents/TableOfContents.js
@@ -1,30 +1,41 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import styles from './TableOfContents.module.scss';
 
 const TITLE_TYPES = new Set(['H2', 'H3', 'H4', 'H5', 'H6']);
 
+function createATag(node) {
+  const { id } = node;
+  const AStart = `<a href=#${id} >`;
+  const AEnd = '</a>';
+
+  node.removeAttribute('id');
+
+  return AStart + node.outerHTML + AEnd;
+}
+
 const TableOfContents = ({ html }) => {
-  const ref = useRef();
+  const el = document.createElement('html');
+  el.innerHTML = html;
+  const body = el.lastChild;
+  const children = body.childNodes;
 
-  useEffect(() => {
-    const el = document.createElement('html');
-    el.innerHTML = html;
-    const body = el.lastChild;
-    const children = body.childNodes;
+  const titles = Array.prototype.slice
+    .call(children)
+    .filter((child) => TITLE_TYPES.has(child.nodeName));
 
-    const titles = Array.prototype.slice
-      .call(children)
-      .filter((child) => TITLE_TYPES.has(child.nodeName));
-
-    titles.forEach((title) => {
-      ref.current.appendChild(title); // why does this break the scroll
-    });
-  }, []);
+  let output = '';
+  titles.forEach((title) => {
+    title.removeChild(title.firstChild);
+    output += createATag(title);
+  });
 
   return (
     <div className={styles['toc']}>
-      <h2>Table of Contents</h2>
-      <div className={styles['toc__content']} ref={ref}></div>
+      <h2 className={styles['toc__title']}>table of contents</h2>
+      <div
+        className={styles['toc__content']}
+        dangerouslySetInnerHTML={{ __html: output }}
+      ></div>
     </div>
   );
 };

--- a/src/components/Post/TableOfContents/TableOfContents.js
+++ b/src/components/Post/TableOfContents/TableOfContents.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './TableOfContents.module.scss';
 
 const TITLE_TYPES = new Set(['H2', 'H3', 'H4', 'H5', 'H6']);
@@ -14,27 +14,33 @@ function createATag(node) {
 }
 
 const TableOfContents = ({ html }) => {
-  const el = document.createElement('html');
-  el.innerHTML = html;
-  const body = el.lastChild;
-  const children = body.childNodes;
+  const [htmlString, setHtmlString] = useState('');
 
-  const titles = Array.prototype.slice
-    .call(children)
-    .filter((child) => TITLE_TYPES.has(child.nodeName));
+  useEffect(() => {
+    const el = document.createElement('html');
+    el.innerHTML = html;
+    const body = el.lastChild;
+    const children = body.childNodes;
 
-  let output = '';
-  titles.forEach((title) => {
-    title.removeChild(title.firstChild);
-    output += createATag(title);
-  });
+    const titles = Array.prototype.slice
+      .call(children)
+      .filter((child) => TITLE_TYPES.has(child.nodeName));
+
+    let s = '';
+    titles.forEach((title) => {
+      title.removeChild(title.firstChild);
+      s += createATag(title);
+    });
+
+    setHtmlString(s);
+  }, []);
 
   return (
     <div className={styles['toc']}>
       <h2 className={styles['toc__title']}>table of contents</h2>
       <div
         className={styles['toc__content']}
-        dangerouslySetInnerHTML={{ __html: output }}
+        dangerouslySetInnerHTML={{ __html: htmlString }}
       ></div>
     </div>
   );

--- a/src/components/Post/TableOfContents/TableOfContents.js
+++ b/src/components/Post/TableOfContents/TableOfContents.js
@@ -1,0 +1,32 @@
+import React, { useRef, useEffect } from 'react';
+import styles from './TableOfContents.module.scss';
+
+const TITLE_TYPES = new Set(['H2', 'H3', 'H4', 'H5', 'H6']);
+
+const TableOfContents = ({ html }) => {
+  const ref = useRef();
+
+  useEffect(() => {
+    const el = document.createElement('html');
+    el.innerHTML = html;
+    const body = el.lastChild;
+    const children = body.childNodes;
+
+    const titles = Array.prototype.slice
+      .call(children)
+      .filter((child) => TITLE_TYPES.has(child.nodeName));
+
+    titles.forEach((title) => {
+      ref.current.appendChild(title);
+    });
+  }, []);
+
+  return (
+    <div className={styles['toc']}>
+      <h2>Table of Contents</h2>
+      <div className={styles['toc__content']} ref={ref}></div>
+    </div>
+  );
+};
+
+export default TableOfContents;

--- a/src/components/Post/TableOfContents/TableOfContents.js
+++ b/src/components/Post/TableOfContents/TableOfContents.js
@@ -5,12 +5,10 @@ const TITLE_TYPES = new Set(['H2', 'H3', 'H4', 'H5', 'H6']);
 
 function createATag(node) {
   const { id } = node;
-  const AStart = `<a href=#${id} >`;
-  const AEnd = '</a>';
 
   node.removeAttribute('id');
 
-  return AStart + node.outerHTML + AEnd;
+  return `<a href=#${id}>${node.outerHTML}</a>`;
 }
 
 const TableOfContents = ({ html }) => {

--- a/src/components/Post/TableOfContents/TableOfContents.module.scss
+++ b/src/components/Post/TableOfContents/TableOfContents.module.scss
@@ -3,22 +3,61 @@
 .toc {
   position: fixed; /* Fixed Sidebar (stay in place on scroll) */
   z-index: 1; /* Stay on top */
-  top: 200px; /* Stay at the top */
+  top: 150px; /* Stay at the top */
   right: calc(((100vw - #{$layout-width}) / 2) - 100px);
-  overflow-x: hidden; /* Disable horizontal scroll */
   padding-top: 20px;
   color: white;
   padding-left: 50px;
+  max-width: 275px;
+  max-height: 500px;
+  overflow-y: scroll;
 
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
+  &__title {
+    font-family: $typographic-font-mono;
+    color: $color-pink-light;
+    font-size: 1.5rem;
     margin: 0px;
   }
 
-  h3 {
+  &__content {
     margin-left: 20px;
+
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin: 0px;
+      margin-bottom: 7px;
+      font-family: $typographic-font-basic;
+      line-height: normal;
+    }
+
+    a {
+      transition: text-shadow 100ms;
+
+      &:hover,
+      &:focus {
+        text-decoration: none !important;
+        text-shadow: 7px 7px 10px black;
+      }
+    }
+
+    h2 {
+      color: $color-gray-light;
+      font-size: 1.2rem;
+    }
+
+    h3 {
+      color: $color-gray-medium;
+      margin-left: 10px;
+      font-size: 1rem;
+    }
+
+    h4 {
+      color: $color-gray-medium;
+      font-size: 0.8rem;
+      margin-left: 20px;
+    }
   }
 }

--- a/src/components/Post/TableOfContents/TableOfContents.module.scss
+++ b/src/components/Post/TableOfContents/TableOfContents.module.scss
@@ -1,0 +1,24 @@
+@import '../../../assets/scss/variables';
+
+.toc {
+  position: fixed; /* Fixed Sidebar (stay in place on scroll) */
+  z-index: 1; /* Stay on top */
+  top: 200px; /* Stay at the top */
+  right: calc(((100vw - #{$layout-width}) / 2) - 100px);
+  overflow-x: hidden; /* Disable horizontal scroll */
+  padding-top: 20px;
+  color: white;
+  padding-left: 50px;
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0px;
+  }
+
+  h3 {
+    margin-left: 20px;
+  }
+}

--- a/src/components/Post/TableOfContents/TableOfContents.module.scss
+++ b/src/components/Post/TableOfContents/TableOfContents.module.scss
@@ -63,7 +63,7 @@
   }
 }
 
-@media screen and (max-width: $layout-breakpoint-sm) {
+@media screen and (max-width: $layout-breakpoint-lg) {
   .toc {
     display: none;
   }

--- a/src/components/Post/TableOfContents/TableOfContents.module.scss
+++ b/src/components/Post/TableOfContents/TableOfContents.module.scss
@@ -1,4 +1,5 @@
 @import '../../../assets/scss/variables';
+@import '../../../assets/scss/mixins';
 
 .toc {
   position: fixed; /* Fixed Sidebar (stay in place on scroll) */
@@ -59,5 +60,11 @@
       font-size: 0.8rem;
       margin-left: 20px;
     }
+  }
+}
+
+@media screen and (max-width: $layout-breakpoint-sm) {
+  .toc {
+    display: none;
   }
 }

--- a/src/components/Post/TableOfContents/TableOfContents.module.scss
+++ b/src/components/Post/TableOfContents/TableOfContents.module.scss
@@ -2,9 +2,9 @@
 @import '../../../assets/scss/mixins';
 
 .toc {
-  position: fixed; /* Fixed Sidebar (stay in place on scroll) */
-  z-index: 1; /* Stay on top */
-  top: 150px; /* Stay at the top */
+  position: fixed;
+  z-index: 1;
+  top: 150px;
   right: calc(((100vw - #{$layout-width}) / 2) - 100px);
   padding-top: 20px;
   color: white;

--- a/src/components/Post/TableOfContents/index.js
+++ b/src/components/Post/TableOfContents/index.js
@@ -1,0 +1,1 @@
+export { default } from './TableOfContents';


### PR DESCRIPTION
This PR adds a sticky table of contents to the right of posts. It's only visible for screen sizes of `$layout-breakpoint-lg` (`1100px`) and up (I considered shoving it under the title for smaller screens but think it looks too much of a long boi).

On MBP 13": 
![122995655_632055407678311_123198140323087338_n](https://user-images.githubusercontent.com/51099886/97649205-1d28dd80-1a2d-11eb-8942-0d0833877fe3.png)

In `Post.js`, I pass in the `html` string to the component. Then I create an `html` document element in order to traverse the DOM tree and grab the header elements. For each of header elements, I remove their one child (which was the [`gatsby-remark-autolink-headers`](https://www.gatsbyjs.com/plugins/gatsby-remark-autolink-headers/) anchor. Then I wrap the header node in an `<a>` tag, with the header's `id` as the `href`. IMPORTANT: you have to remove the `id` attribute of the header or else `gatsby-remark-autolink-headers` breaks since it'll use the links in this new component. Finally, I `dangerouslySetInnerHTML` this generated string. Honestly, not very elegant at all 😬

Currently, the CSS only supports up to `h4` because I don't anticipate using smaller headers than that (don't even think I use `h4`s anywhere yet). 

Iffy about: 
- just if this is the right way to go about it?????
- `text-shadow` hover -- it's not super apparent; maybe underline is better?
- `max-width`/`max-height`/positioning of component (I did a jank calculation) 